### PR TITLE
Fix for Setuptools>=66

### DIFF
--- a/marrow/mailer/release.py
+++ b/marrow/mailer/release.py
@@ -5,7 +5,7 @@
 from collections import namedtuple
 
 
-version_info = namedtuple('version_info', ('major', 'minor', 'micro', 'releaselevel', 'serial'))(4, 1, 3, 'dev', 0)
+version_info = namedtuple('version_info', ('major', 'minor', 'micro', 'releaselevel', 'serial'))(4, 1, 3, 'b', 0)
 version = ".".join([str(i) for i in version_info[:3]]) + ((version_info.releaselevel[0] + str(version_info.serial)) if version_info.releaselevel != 'final' else '')
 
 author = namedtuple('Author', ['name', 'email'])("Alice Bevan-McGregor", 'alice@gothcandy.com')


### PR DESCRIPTION
### Problem
Problem from setuptools version 66 they only allow versions in follow format.
4.1.3.d0 is not allowed.  

**Error**
      `setuptools.extern.packaging.version.InvalidVersion: Invalid version: '4.1.3d0'`

### Background information
A pre-release tag is a series of letters that are alphabetically before “final”. Some examples of prerelease tags would include alpha, beta, a, c, dev, and so on. You do not have to place a dot or dash before the prerelease tag if it’s immediately after a number, but it’s okay to do so if you prefer. Thus, 2.4c1 and 2.4.c1 and 2.4-c1 all represent release candidate 1 of version 2.4, and are treated as identical by setuptools. Note that only a, b, and rc are [PEP 440](https://peps.python.org/pep-0440/)-compliant pre-release tags.
source: https://setuptools.pypa.io/en/latest/userguide/distribution.html